### PR TITLE
feat: fastify v5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ Inspired by [express-jwt-permissions](https://github.com/MichielDeMey/express-jw
 $ npm install fastify-guard
 ```
 
+### Compatibility
+
+| Plugin version | Fastify version |
+| -------------- |---------------- |
+| `^3.0.0`       | `^5.0.0`        |
+| `^2.0.0`       | `^4.0.0`        |
+| `^1.0.0`       | `^3.0.0`        |
+
 ## Usage
 
 ```js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-guard",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "a simple user role and scope checker plugin to protect endpoints for Fastify",
   "main": "src/index.js",
   "scripts": {
@@ -31,12 +31,12 @@
     "node": ">=14.0.0"
   },
   "dependencies": {
-    "fastify-plugin": "^3.0.1",
+    "fastify-plugin": "^5.0.1",
     "http-errors": "^2.0.0"
   },
   "devDependencies": {
     "@types/http-errors": "^1.8.2",
-    "fastify": "^4.2.0",
+    "fastify": "^5.0.0",
     "jest": "^28.1.2",
     "standard": "^17.0.0",
     "tsd": "^0.20.0"

--- a/src/index.js
+++ b/src/index.js
@@ -159,7 +159,7 @@ function guardPlugin (fastify, opts, next) {
 module.exports = fastifyPlugin(
   guardPlugin,
   {
-    fastify: '4.x',
+    fastify: '5.x',
     name: pkg.name
   }
 )


### PR DESCRIPTION
Hi, I tried to make a PR for fastify v5 compatibility.

I did not have to make any code changes, all tests were passing after the fastify v5 update!

I also updated the README and added a compatibility section like other official fastify plugins do (see for example https://github.com/fastify/fastify-sensible/tree/master?tab=readme-ov-file#compatibility).

This should fix the issue #15 opened by @TobiasLC.